### PR TITLE
fixed "already initialized constant" warnings 

### DIFF
--- a/lib/signet/oauth_1/client.rb
+++ b/lib/signet/oauth_1/client.rb
@@ -14,7 +14,7 @@
 
 gem 'faraday', '~> 0.8.1'
 require 'faraday'
-require 'faraday/utils'
+#require 'faraday/utils'
 
 require 'stringio'
 require 'addressable/uri'

--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -14,7 +14,7 @@
 
 gem 'faraday', '~> 0.8.1'
 require 'faraday'
-require 'faraday/utils'
+#require 'faraday/utils'
 
 require 'stringio'
 require 'addressable/uri'


### PR DESCRIPTION
faraday already requires faraday/utils so I commented out the line require 'faraday/utils' from client.rb in both lib/signet/oauth_x/ directories to get rid of the "already initialized constant" warnings that were appearing in ree-1.8.7

---

The build is failing on Travis CI for some versions of ruby, with a "Signet::AuthorizationError: 464 Authorization failed.  Server message: 465 Timestamp is too far from current time", even though I only touched those two lines (which seem unrelated). The failures don't happen locally, so it looks like it might just be a clock issue.
