### PR TITLE
Add magic comment US-ASCII for Ruby2.0.0

### DIFF
--- a/lib/signet.rb
+++ b/lib/signet.rb
@@ -1,3 +1,4 @@
+# coding: US-ASCII
 # Copyright (C) 2010 Google Inc.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Ruby2.0.0 default encoding is UTF-8 instead of US_ASCII
