### PR TITLE
Fix invalid regex encoding

### DIFF
--- a/lib/signet.rb
+++ b/lib/signet.rb
@@ -19,12 +19,12 @@ module Signet #:nodoc:
     # Production rules from:
     # http://tools.ietf.org/html/draft-ietf-httpbis-p1-messaging-12
     token = /[-!#$\%&'*+.^_`|~0-9a-zA-Z]+/
-    d_qdtext = /[\s\x21\x23-\x5B\x5D-\x7E\x80-\xFF]/
-    d_quoted_pair = /\\[\s\x21-\x7E\x80-\xFF]/
+    d_qdtext = /[\s\x21\x23-\x5B\x5D-\x7E\x80-\xFF]/n
+    d_quoted_pair = /\\[\s\x21-\x7E\x80-\xFF]/n
     d_qs = /"(?:#{d_qdtext}|#{d_quoted_pair})*"/
     # Production rules that allow for more liberal parsing, i.e. single quotes
-    s_qdtext = /[\s\x21-\x26\x28-\x5B\x5D-\x7E\x80-\xFF]/
-    s_quoted_pair = /\\[\s\x21-\x7E\x80-\xFF]/
+    s_qdtext = /[\s\x21-\x26\x28-\x5B\x5D-\x7E\x80-\xFF]/n
+    s_quoted_pair = /\\[\s\x21-\x7E\x80-\xFF]/n
     s_qs = /'(?:#{s_qdtext}|#{s_quoted_pair})*'/
     # Combine the above production rules to find valid auth-param pairs.
     auth_param = /((?:#{token})\s*=\s*(?:#{d_qs}|#{s_qs}|#{token}))/


### PR DESCRIPTION
Add regexp encoding option.
https://github.com/google/signet/pull/8 is not enough, so https://travis-ci.org/google/google-api-ruby-client/jobs/4052360 is still syntax error in ruby2.0.0.
