### PR TITLE
Full jruby and rubinius coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,11 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
-  - jruby
+  - rbx-18mode
+  - rbx-19mode
+  - jruby-18mode
+  - jruby-19mode
+  - jruby-20mode
   - ree
 script: "bundle exec rake spec:normal"
 jdk: openjdk7
@@ -19,6 +23,3 @@ notifications:
       - sbazyl@google.com
     on_success: change
     on_failure: change
-matrix:
-  allow_failures:
-    - rvm: 2.0.0


### PR DESCRIPTION
Also, making 2.0.0 a required version target now that it's released
