### PR TITLE
Use https://rubygems.org instead of :rubygems as source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'addressable', '>= 2.3.1'
 gem 'faraday', '~> 0.8.1'


### PR DESCRIPTION
`:rubygems` is deprecated.
