### PR TITLE
Makes prompt=consent rather than approval_prompt=force by default and does not set a default prompt value if approval_prompt is passed.

### DIFF
--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -244,11 +244,11 @@ module Signet
         unless options[:access_type]
           options[:access_type] = :offline
         end
-        if !options[:prompt] && !options[:approval_prompt]
-          options[:prompt] = :consent
-        end
         options[:client_id] ||= self.client_id
         options[:redirect_uri] ||= self.redirect_uri
+        if options[:prompt] && options[:approval_prompt]
+          raise ArgumentError, "prompt and approval_prompt are mutually exclusive parameters"
+        end
         if !options[:client_id]
           raise ArgumentError, "Missing required client identifier."
         end

--- a/spec/signet/oauth_2/client_spec.rb
+++ b/spec/signet/oauth_2/client_spec.rb
@@ -828,10 +828,6 @@ describe Signet::OAuth2::Client, 'authorization_uri' do
     )
   end
 
-  it 'should set prompt to consent by default' do
-    @client.authorization_uri.query_values['prompt'].should == 'consent'
-  end
-
   it 'should set access_type to offline by default' do
     @client.authorization_uri.query_values['access_type'].should == 'offline'
   end
@@ -840,7 +836,9 @@ describe Signet::OAuth2::Client, 'authorization_uri' do
     @client.authorization_uri.query_values['response_type'].should == 'code'
   end
 
-  it 'should not include prompt if approval_prompt is passed as an option' do
-    @client.authorization_uri(:approval_prompt => 'force').query_values['prompt'].should be_nil
+  it 'should raise an error when setting both prompt and approval_prompt' do
+    (lambda do
+      @client.authorization_uri(:approval_prompt => 'force', :prompt => 'consent')
+    end).should raise_error(ArgumentError)
   end
 end


### PR DESCRIPTION
This fixes the issue https://github.com/google/signet/issues/22 
