### PR TITLE
Fix invalid multibyte escape error.

### DIFF
--- a/lib/signet.rb
+++ b/lib/signet.rb
@@ -1,3 +1,4 @@
+# encoding: ascii
 # Copyright (C) 2010 Google Inc.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
I'm trying out google I/O's example Rails app: quizzimoto, and ran into these errors while doing `rake db:migrate` :

```
/Users/Mac/.rvm/gems/ruby-2.0.0-p247@quiz2/gems/signet-0.3.2/lib/signet.rb:22: invalid multibyte escape: /[\s\x21\x23-\x5B\x5D-\x7E\x80-\xFF]/
invalid multibyte escape: /\\[\s\x21-\x7E\x80-\xFF]/
invalid multibyte escape: /[\s\x21-\x26\x28-\x5B\x5D-\x7E\x80-\xFF]/
invalid multibyte escape: /\\[\s\x21-\x7E\x80-\xFF]/
```

I'm using Ruby 2.0.0-p247 and signet-0.3.2.
