### PR TITLE
Allow token_credential_url to be set to a Hash

### DIFF
--- a/lib/signet/oauth_1/client.rb
+++ b/lib/signet/oauth_1/client.rb
@@ -186,12 +186,14 @@ module Signet
       ##
       # Sets the token credential URI for this client.
       #
-      # @param [Addressable::URI, String, #to_str] new_token_credential_uri
+      # @param [Addressable::URI, Hash, String, #to_str] new_token_credential_uri
       #   The token credential URI.
       def token_credential_uri=(new_token_credential_uri)
         if new_token_credential_uri != nil
-          new_token_credential_uri =
-            Addressable::URI.parse(new_token_credential_uri)
+          new_token_credential_uri = Addressable::URI.send(
+            new_token_credential_uri.kind_of?(Hash) ? :new : :parse,
+            new_token_credential_uri
+          )
           @token_credential_uri = new_token_credential_uri
         else
           @token_credential_uri = nil

--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -294,12 +294,14 @@ module Signet
       ##
       # Sets the token credential URI for this client.
       #
-      # @param [Addressable::URI, String, #to_str] new_token_credential_uri
+      # @param [Addressable::URI, Hash, String, #to_str] new_token_credential_uri
       #   The token credential URI.
       def token_credential_uri=(new_token_credential_uri)
         if new_token_credential_uri != nil
-          new_token_credential_uri =
-            Addressable::URI.parse(new_token_credential_uri)
+          new_token_credential_uri = Addressable::URI.send(
+            new_token_credential_uri.kind_of?(Hash) ? :new : :parse,
+            new_token_credential_uri
+          )
           @token_credential_uri = new_token_credential_uri
         else
           @token_credential_uri = nil

--- a/spec/signet/oauth_1/client_spec.rb
+++ b/spec/signet/oauth_1/client_spec.rb
@@ -92,6 +92,13 @@ describe Signet::OAuth1::Client, 'unconfigured' do
     @client.token_credential_uri.should === "http://example.com/"
   end
 
+  it 'should allow the token_credential_uri to be set to a Hash' do
+    @client.token_credential_uri = {
+      :scheme => 'http', :host => 'example.com', :path => '/token'
+    }
+    @client.token_credential_uri.to_s.should === 'http://example.com/token'
+  end
+
   it 'should allow the token_credential_uri to be set to a URI' do
     @client.token_credential_uri =
       Addressable::URI.parse("http://example.com/")

--- a/spec/signet/oauth_2/client_spec.rb
+++ b/spec/signet/oauth_2/client_spec.rb
@@ -166,6 +166,13 @@ describe Signet::OAuth2::Client, 'unconfigured' do
     @client.token_credential_uri.should === "https://example.com/token"
   end
 
+  it 'should allow the token_credential_uri to be set to a Hash' do
+    @client.token_credential_uri = {
+      :scheme => 'https', :host => 'example.com', :path => '/token'
+    }
+    @client.token_credential_uri.to_s.should === 'https://example.com/token'
+  end
+
   it 'should allow the token_credential_uri to be set to a URI' do
     @client.token_credential_uri =
       Addressable::URI.parse("https://example.com/token")


### PR DESCRIPTION
I fixed the issues from my original PR #31

The same fix as in c3efb8b, but for token_credential_uri. See google/google-api-ruby-client#90
