### PR TITLE
@sporkmonger:  Added function-paramter to wrapping function in OAuth2-Client

### DIFF
--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -967,8 +967,8 @@ module Signet
 
       ##
       # Refresh the access token, if possible
-      def refresh!
-        self.fetch_access_token!
+      def refresh!(options={})
+        self.fetch_access_token!(options)
       end
 
       ##


### PR DESCRIPTION
@ sporkmonger (maintainer):
Wrapper refresh!() accepts same parameter as wrapped function fetch_access_token!().
For some services, it is necessary to send specific individual additional parameters when refreshing the access token, eg. Highrise expects the parameter "type" to be set to "refresh".
