### PR TITLE
Changes to OAuth2 authentication JSON output

### DIFF
--- a/lib/signet/oauth_2.rb
+++ b/lib/signet/oauth_2.rb
@@ -148,6 +148,9 @@ module Signet #:nodoc:
       end
       parsed_uri = Addressable::URI.parse(authorization_uri).dup
       query_values = parsed_uri.query_values || {}
+      query_values.keys.each do |key|
+        query_values[(key.to_sym rescue key) || key] = query_values.delete(key)
+      end
       query_values = query_values.merge(parameters)
       parsed_uri.query_values = query_values
       return parsed_uri.normalize.to_s

--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -738,7 +738,7 @@ module Signet
       # @param [String] new_issued_at
       #    The access token issuance time.
       def issued_at=(new_issued_at)
-        @issued_at = Time.at new_issued_at
+        @issued_at = Time.at(new_issued_at) rescue nil
       end
 
       ##

--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -297,7 +297,7 @@ module Signet
         @token_credential_uri = coerce_uri(new_token_credential_uri)
       end
 
-      # Addressable expects URIs formatted as hashes to come in with symbols as keys. 
+      # Addressable expects URIs formatted as hashes to come in with symbols as keys.
       # Returns nil implicitly for the nil case.
       def coerce_uri(incoming_uri)
         if incoming_uri.is_a? Hash
@@ -738,7 +738,7 @@ module Signet
       # @param [String] new_issued_at
       #    The access token issuance time.
       def issued_at=(new_issued_at)
-        @issued_at = new_issued_at
+        @issued_at = Time.at new_issued_at
       end
 
       ##
@@ -864,6 +864,8 @@ module Signet
           'audience' => self.audience,
           'person' => self.person,
           'expiry' => self.expiry,
+          'expires_in' => self.expires_in,
+          'issued_at' => self.issued_at.to_i,
           'signing_key' => self.signing_key,
           'refresh_token' => self.refresh_token,
           'access_token' => self.access_token,
@@ -1130,7 +1132,7 @@ module Signet
       def uri_is_oob?(uri)
         return uri.to_s == 'urn:ietf:wg:oauth:2.0:oob' || uri.to_s == 'oob'
       end
-      
+
       # Convert all keys in this hash (nested) to symbols for uniform retrieval
       def recursive_hash_normalize_keys(val)
         if val.is_a? Hash


### PR DESCRIPTION
Example code located on the Google developers site for Ruby (https://developers.google.com/api-client-library/ruby/auth/web-app) utilizes the JSON output of the authentication information in a stored session for creating the OAuth2 client. While this works correctly for the first fetch of the access token, the JSON output does not provide adequate information regarding the expiration of the access token. With out the expiration information it is impossible to track and test for an expired access token in subsequent API executions. The changes in this PR add the **expires_in** and **issued_at** parameters to the JSON output which allows the client to properly track and verify if the access token has expired.

Additionally, while testing the creation of an OAuth2 client using the JSON output I came across an exception with how the authorization URI was being created. The following error was reported:

```
/usr/local/lib/ruby/gems/2.1.0/gems/addressable-2.3.6/lib/addressable/uri.rb:1579:in `sort!': comparison of Array with Array failed (ArgumentError)
    from /usr/local/lib/ruby/gems/2.1.0/gems/addressable-2.3.6/lib/addressable/uri.rb:1579:in `query_values='
    from /usr/local/lib/ruby/gems/2.1.0/gems/signet-0.6.0/lib/signet/oauth_2.rb:152:in `generate_authorization_uri'
    from /usr/local/lib/ruby/gems/2.1.0/gems/signet-0.6.0/lib/signet/oauth_2/client.rb:263:in `authorization_uri'
    from /usr/local/lib/ruby/gems/2.1.0/gems/signet-0.6.0/lib/signet/oauth_2/client.rb:853:in `to_json'
```

The issue was the result of mismatched hash key types ... the resulting merge of the query_values hash had a mix of both Symbol and String key types. This PR includes changes to normalize the query_values hash before the merge.
