### PR TITLE
Don't doubly encode ampersand in OAuth1 plaintext signature method

### DIFF
--- a/lib/signet/oauth_1/signature_methods/plaintext.rb
+++ b/lib/signet/oauth_1/signature_methods/plaintext.rb
@@ -13,8 +13,7 @@ module Signet #:nodoc:
         # The key for the signature is just the client secret and token
         # secret joined by the '&' character.  If the token secret is omitted,
         # the '&' must still be present.
-        key = [client_credential_secret, token_credential_secret].join("&")
-        return Signet::OAuth1.encode(key).strip
+        [client_credential_secret, token_credential_secret].join("&").strip
       end
     end
   end

--- a/spec/signet/oauth_1/signature_methods/plaintext_spec.rb
+++ b/spec/signet/oauth_1/signature_methods/plaintext_spec.rb
@@ -35,7 +35,7 @@ describe Signet::OAuth1::PLAINTEXT do
     base_string = Signet::OAuth1.generate_base_string(method, uri, parameters)
     expect(Signet::OAuth1::PLAINTEXT.generate_signature(
         base_string, client_credential_secret, token_credential_secret
-    )).to eq "kd94hf93k423kf44%26pfkkdhi9sl3r4s00"
+    )).to eq "kd94hf93k423kf44&pfkkdhi9sl3r4s00"
   end
 
   it 'should correctly generate a signature' do
@@ -56,6 +56,6 @@ describe Signet::OAuth1::PLAINTEXT do
     base_string = Signet::OAuth1.generate_base_string(method, uri, parameters)
     expect(Signet::OAuth1::PLAINTEXT.generate_signature(
         base_string, client_credential_secret, token_credential_secret
-    )).to eq "Kv%252Bo2XXL%252F9RxkQW3lO3QTVlH%26QllSuL9eQ5FXFO1Z%252FHcgL4ON"
+    )).to eq "Kv%2Bo2XXL%2F9RxkQW3lO3QTVlH&QllSuL9eQ5FXFO1Z%2FHcgL4ON"
   end
 end


### PR DESCRIPTION
I was having trouble connecting to an OAuth1 provider with the PLAINTEXT signature method using Signet. It seems that the ampersand in the signature is being doubly encoded, and that therefore my OAuth1 provider fails to accept the signature.
1. The ampersand is first encoded in [plaintext.rb](https://github.com/google/signet/blob/master/lib/signet/oauth_1/signature_methods/plaintext.rb#L17).
2. The signature value is then passed through `generate_temporary_credential_request` / `generate_token_credential_request` / `generate_authenticated_request` to [`generate_authorization_header`](https://github.com/google/signet/blob/master/lib/signet/oauth_1.rb#L217) where the value (the signature) is encoded again.

I removed the encoding step in the generation of the signature itself, and let it be encoded properly in `generate_authorization_header`. I updated the plaintext test case accordingly. I'm wondering if this fix is correct and how the compatibility is for other providers, seeing that this library has been doing this for such a long time already.
