### PR TITLE
Handle unexpected status errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.10.0 (2018-09-21)
+* Add UnexpectedStatusError class for http status errors that are not handled.
+
 ## 0.9.2 (2018-09-12)
 * Update issued_at correctly when it is set simultaneously with expires_in.
 

--- a/lib/signet/errors.rb
+++ b/lib/signet/errors.rb
@@ -40,6 +40,11 @@ module Signet
   end
 
   ##
+  # An error indicating that the server sent an unexpected http status
+  class UnexpectedStatusError < StandardError
+  end
+
+  ##
   # An error indicating the remote server refused to authorize the client.
   class AuthorizationError < StandardError
     ##

--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -1001,9 +1001,7 @@ module Signet
           if body.to_s.strip.length > 0
             message += "  Server message:\n#{response.body.to_s.strip}"
           end
-          raise ::Signet::AuthorizationError.new(
-            message, :response => response
-          )
+          raise ::Signet::UnexpectedStatusError.new(message)
         end
       end
 

--- a/lib/signet/version.rb
+++ b/lib/signet/version.rb
@@ -17,8 +17,8 @@ unless defined? Signet::VERSION
   module Signet
     module VERSION
       MAJOR = 0
-      MINOR = 9
-      TINY  = 2
+      MINOR = 10
+      TINY  = 0
       PRE   = nil
 
       STRING = [MAJOR, MINOR, TINY, PRE].compact.join('.')

--- a/spec/signet/oauth_2/client_spec.rb
+++ b/spec/signet/oauth_2/client_spec.rb
@@ -554,7 +554,7 @@ describe Signet::OAuth2::Client, 'configured for Google userinfo API' do
     stubs.verify_stubbed_calls
   end
 
-  it 'should raise an error if the token server gives an unexpected status' do
+  it 'should raise an unexpected error if the token server gives an unexpected status' do
     @client.client_id = 'client-12345'
     @client.client_secret = 'secret-12345'
     stubs = Faraday::Adapter::Test::Stubs.new do |stub|
@@ -569,7 +569,7 @@ describe Signet::OAuth2::Client, 'configured for Google userinfo API' do
       @client.fetch_access_token!(
         :connection => connection
       )
-    end).to raise_error(Signet::AuthorizationError)
+    end).to raise_error(Signet::UnexpectedStatusError)
     stubs.verify_stubbed_calls
   end
 


### PR DESCRIPTION
Currently unexpected status errors return a Signet::AuthorizationError which is misleading

I added a Signet::UnexpectedStatusError so they can be distinguished