### PR TITLE
 Calculate expires_at from issued_at, if provided

### DIFF
--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -1203,7 +1203,6 @@ module Signet
       end
 
       def set_relative_expires_at(issued_at, expires_in)
-        self.expires_in = expires_in.to_i
         self.issued_at = issued_at
         # Using local expires_in because if self.expires_in is used, it returns
         # the time left before the token expires

--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -224,13 +224,13 @@ module Signet
         # Normalize all keys to symbols to allow indifferent access internally
         options = deep_hash_normalize(options)
 
-        self.expires_in = options[:expires] if options.has_key?(:expires)
-        self.expires_in = options[:expires_in] if options.has_key?(:expires_in)
-        self.expires_at = options[:expires_at] if options.has_key?(:expires_at)
-
         # By default, the token is issued at `Time.now` when `expires_in` is
         # set, but this can be used to supply a more precise time.
         self.issued_at = options[:issued_at] if options.has_key?(:issued_at)
+
+        self.expires_in = options[:expires] if options.has_key?(:expires)
+        self.expires_in = options[:expires_in] if options.has_key?(:expires_in)
+        self.expires_at = options[:expires_at] if options.has_key?(:expires_at)
 
         self.access_token = options[:access_token] if options.has_key?(:access_token)
         self.refresh_token = options[:refresh_token] if options.has_key?(:refresh_token)
@@ -742,7 +742,7 @@ module Signet
       #   The access token lifetime.
       def expires_in=(new_expires_in)
         if new_expires_in != nil
-          @issued_at = Time.now
+          @issued_at ||= Time.now
           @expires_at = @issued_at + new_expires_in.to_i
         else
           @expires_at, @issued_at = nil, nil
@@ -768,7 +768,7 @@ module Signet
 
       ##
       # Returns the timestamp the access token will expire at.
-      # Returns nil if the token does not expire. 
+      # Returns nil if the token does not expire.
       #
       # @return [Time, nil] The access token lifetime.
       def expires_at

--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -748,7 +748,7 @@ module Signet
       #   The access token lifetime.
       def expires_in=(new_expires_in)
         if new_expires_in != nil
-          @issued_at = normalize_timestamp(Time.now)
+          @issued_at = Time.now
           @expires_at = @issued_at + new_expires_in.to_i
         else
           @expires_at, @issued_at = nil, nil

--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -233,7 +233,7 @@ module Signet
         # set, but this can be used to supply a more precise time.
         self.issued_at = options[:issued_at] if options.has_key?(:issued_at)
 
-        # Special case where we want expires_in to be relative to issued_at
+        # Special case where we want expires_at to be relative to issued_at
         if options.has_key?(:issued_at) && options.has_key?(:expires_in)
           set_relative_expires_at options[:issued_at], options[:expires_in]
         end

--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -225,13 +225,18 @@ module Signet
         # Normalize all keys to symbols to allow indifferent access internally
         options = deep_hash_normalize(options)
 
+        self.expires_in = options[:expires] if options.has_key?(:expires)
+        self.expires_in = options[:expires_in] if options.has_key?(:expires_in)
+        self.expires_at = options[:expires_at] if options.has_key?(:expires_at)
+
         # By default, the token is issued at `Time.now` when `expires_in` is
         # set, but this can be used to supply a more precise time.
         self.issued_at = options[:issued_at] if options.has_key?(:issued_at)
 
-        self.expires_in = options[:expires] if options.has_key?(:expires)
-        self.expires_in = options[:expires_in] if options.has_key?(:expires_in)
-        self.expires_at = options[:expires_at] if options.has_key?(:expires_at)
+        # Special case where we want expires_in to be relative to issued_at
+        if options.has_key?(:issued_at) && options.has_key?(:expires_in)
+          set_relative_expires_at options[:issued_at], options[:expires_in]
+        end
 
         self.access_token = options[:access_token] if options.has_key?(:access_token)
         self.refresh_token = options[:refresh_token] if options.has_key?(:refresh_token)
@@ -743,7 +748,7 @@ module Signet
       #   The access token lifetime.
       def expires_in=(new_expires_in)
         if new_expires_in != nil
-          @issued_at ||= Time.now
+          @issued_at = normalize_timestamp(Time.now)
           @expires_at = @issued_at + new_expires_in.to_i
         else
           @expires_at, @issued_at = nil, nil
@@ -1195,6 +1200,14 @@ module Signet
         else
           fail "Invalid time value #{time}"
         end
+      end
+
+      def set_relative_expires_at(issued_at, expires_in)
+        self.expires_in = expires_in.to_i
+        self.issued_at = issued_at
+        # Using local expires_in because if self.expires_in is used, it returns
+        # the time left before the token expires
+        self.expires_at = self.issued_at + expires_in.to_i
       end
     end
   end

--- a/spec/signet/oauth_2/client_spec.rb
+++ b/spec/signet/oauth_2/client_spec.rb
@@ -455,6 +455,22 @@ describe Signet::OAuth2::Client, 'configured for Google userinfo API' do
     expect(@client).to_not be_expired
   end
 
+  # This test is to document the way that expires_in has always been used:
+  # If expires_in is set on the client, it always resets the issued_at time
+  # to Time.now
+  it 'sets issued_at to Time.now when expires_in is not set through update_token!' do
+    one_hour = 3600
+    issued_at = Time.now - (2 * one_hour)
+    current_time = Time.now
+
+    @client.issued_at = issued_at
+    @client.expires_in = one_hour
+
+    expect(@client.issued_at).to_not eq issued_at
+    expect(@client.issued_at).to be_within(1).of(current_time)
+    expect(@client).to_not be_expired
+  end
+
   it 'should allow setting expires_at manually' do
     expires_at = Time.now+100
     @client.expires_at = expires_at.to_i

--- a/spec/signet/oauth_2/client_spec.rb
+++ b/spec/signet/oauth_2/client_spec.rb
@@ -435,6 +435,25 @@ describe Signet::OAuth2::Client, 'configured for Google userinfo API' do
     expect(@client).to be_expired
   end
 
+  it 'should calculate the expires_at from issued_at when issued_at is set' do
+    expires_in = 3600
+    issued_at = Time.now - expires_in
+    @client.update_token!(
+      :issued_at => issued_at,
+      :expires_in => expires_in
+    )
+    expect(@client.expires_at).to eq issued_at + expires_in
+    expect(@client).to be_expired
+  end
+
+  it 'should calculate expires_at from Time.now when issed_at is NOT set' do
+    expires_in = 3600
+    expires_at = Time.now + expires_in
+    @client.update_token! :expires_in => expires_in
+    expect(@client.expires_at).to be_within(1).of(expires_at)
+    expect(@client).to_not be_expired
+  end
+
   it 'should allow setting expires_at manually' do
     expires_at = Time.now+100
     @client.expires_at = expires_at.to_i


### PR DESCRIPTION
This pull request fixes a subtle issue where if a user provides `expires_in` and `issued_at`, the `expires_at` is calculated with `Time.now`, causing the client to never be expired.

Examples:
Current result
```ruby
# Assuming the current time is 2018-08-24T12:00:00
client.update_token!(
  expires_in: 3600,
  issued_at: '2018-08-24T00:00:00Z'
)
client.expires_at # => 2018-08-24T13:00:00
client.expired? # => false
```

Expected result
```ruby
# Assuming the current time is 2018-08-24T12:00:00
client.update_token!(
  expires_in: 3600,
  issued_at: '2018-08-24T00:00:00Z'
)
client.expires_at # => 2018-08-24T01:00:00
client.expired? # => true
```

Notice that `self.issued_at =` is moved above the expires code block, as `expires_in=` checks if `self.issued_at` is set or not.