### PR TITLE
Fix audience documentation

### DIFF
--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -540,7 +540,7 @@ module Signet
       end
 
       ##
-      # Returns the issuer ID associated with this client.
+      # Returns the target audience ID when issuing assertions.
       # Used only by the assertion grant type.
       #
       # @return [String] Target audience ID.


### PR DESCRIPTION
Fix the documentation for `Signet::OAuth2::Client#audience`. It looks like it was copied from `#issuer`.