### PR TITLE
Support the array of `aud`

### DIFF
--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -741,7 +741,7 @@ module Signet
         verify = !public_key.nil? || block_given?
         payload, _header = JWT.decode(id_token, public_key, verify, options, &keyfinder)
         raise Signet::UnsafeOperationError, "No ID token audience declared." unless payload.key? "aud"
-        if payload["aud"] != client_id
+        unless Array(payload["aud"]).include?(client_id)
           raise Signet::UnsafeOperationError,
                 "ID token audience did not match Client ID."
         end


### PR DESCRIPTION
Currently, we can not consider the possibility that the type of `payload["aud"]` is an array.
According to the specification of open-id-connect, I think that it is better to support the array.

https://openid.net/specs/openid-connect-core-1_0.html#IDToken
> aud
REQUIRED. Audience(s) that this ID Token is intended for. It MUST contain the OAuth 2.0 client_id of the Relying Party as an audience value. It MAY also contain identifiers for other audiences. In the general case, the aud value is an array of case sensitive strings. In the common special case when there is one audience, the aud value MAY be a single case sensitive string.
