### PR TITLE
Require Ruby 2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.0 (unreleased)
+* Requires Ruby 2.4
+* Support array values of the "aud" field
+
 ## 0.11.0 (2018-10-08)
 * Add constant time comparison for oauth signatures.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 0.12.0 (unreleased)
-* Requires Ruby 2.4
-* Support array values of the "aud" field
-
 ## 0.11.0 (2018-10-08)
 * Add constant time comparison for oauth signatures.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Signet
 
 <dl>
-  <dt>Homepage</dt><dd><a href="http://code.google.com/p/oauth-signet/">http://code.google.com/p/oauth-signet/</a></dd>
+  <dt>Homepage</dt><dd><a href="https://github.com/googleapis/signet/">https://github.com/googleapis/signet/</a></dd>
   <dt>Author</dt><dd><a href="mailto:bobaman@google.com">Bob Aman</a></dd>
   <dt>Copyright</dt><dd>Copyright © 2010 Google, Inc.</dd>
   <dt>License</dt><dd>Apache 2.0</dd>
@@ -59,10 +59,9 @@ client.fetch_access_token!
 Be sure `https://rubygems.org` is in your gem sources.
 
 ## Supported Ruby Versions
-This library is currently supported on Ruby 1.9+.  
-However, Ruby 2.4 or later is strongly recommended, as earlier releases have
-reached or are nearing end-of-life. After March 31, 2019, Google will provide
-official support only for Ruby versions that are considered current and
+
+This library requires Ruby 2.4 or later.
+In general, this library supports Ruby versions that are considered current and
 supported by Ruby Core (that is, Ruby versions that are either in normal
 maintenance or in security maintenance).
 See https://www.ruby-lang.org/en/downloads/branches/ for further details.

--- a/lib/signet/version.rb
+++ b/lib/signet/version.rb
@@ -17,72 +17,11 @@ unless defined? Signet::VERSION
   module Signet
     module VERSION
       MAJOR = 0
-      MINOR = 11
+      MINOR = 12
       TINY  = 0
       PRE   = nil
 
       STRING = [MAJOR, MINOR, TINY, PRE].compact.join "."
-
-      # On March 31, 2019, set supported version to 2.4 and recommended to 2.6.
-      # Thereafter, follow the MRI support schedule: supported means non-EOL,
-      # and recommended means in normal (rather than security) maintenance.
-      # See https://www.ruby-lang.org/en/downloads/branches/
-      ##
-      # Minimum "supported" Ruby version (non-EOL)
-      # @private
-      #
-      SUPPORTED_VERSION_THRESHOLD = "1.9".freeze
-      ##
-      # Minimum "recommended" Ruby version (normal maintenance)
-      # @private
-      #
-      RECOMMENDED_VERSION_THRESHOLD = "2.4".freeze
-      ##
-      # Check Ruby version and emit a warning if it is old
-      # @private
-      #
-      def self.warn_on_old_ruby_version
-        return if ENV["GOOGLE_CLOUD_SUPPRESS_RUBY_WARNINGS"]
-        cur_version = Gem::Version.new RUBY_VERSION
-        if cur_version < Gem::Version.new(SUPPORTED_VERSION_THRESHOLD)
-          warn_unsupported_ruby cur_version, RECOMMENDED_VERSION_THRESHOLD
-        elsif cur_version < Gem::Version.new(RECOMMENDED_VERSION_THRESHOLD)
-          warn_nonrecommended_ruby cur_version, RECOMMENDED_VERSION_THRESHOLD
-        end
-      rescue ArgumentError
-        "Unable to determine current Ruby version."
-      end
-
-      ##
-      # Print a warning for an EOL version of Ruby
-      # @private
-      #
-      def self.warn_unsupported_ruby cur_version, recommended_version
-        "WARNING: You are running Ruby #{cur_version}, which has reached" \
-          " end-of-life and is no longer supported by Ruby Core.\n" \
-          "Signet works best on supported versions of" \
-          " Ruby. It is strongly recommended that you upgrade to Ruby" \
-          " #{recommended_version} or later. \n" \
-          "See https://www.ruby-lang.org/en/downloads/branches/ for more" \
-          " info on the Ruby maintenance schedule.\n" \
-          "To suppress this message, set the" \
-          " GOOGLE_CLOUD_SUPPRESS_RUBY_WARNINGS environment variable."
-      end
-
-      ##
-      # Print a warning for a supported but nearing EOL version of Ruby
-      # @private
-      #
-      def self.warn_nonrecommended_ruby cur_version, recommended_version
-        "WARNING: You are running Ruby #{cur_version}, which is nearing" \
-          " end-of-life.\n" \
-          "Signet works best on supported versions of" \
-          " Ruby. Consider upgrading to Ruby #{recommended_version} or later.\n" \
-          "See https://www.ruby-lang.org/en/downloads/branches/ for more" \
-          " info on the Ruby maintenance schedule.\n" \
-          "To suppress this message, set the" \
-          " GOOGLE_CLOUD_SUPPRESS_RUBY_WARNINGS environment variable."
-      end
     end
   end
 end

--- a/lib/signet/version.rb
+++ b/lib/signet/version.rb
@@ -17,7 +17,7 @@ unless defined? Signet::VERSION
   module Signet
     module VERSION
       MAJOR = 0
-      MINOR = 12
+      MINOR = 11
       TINY  = 0
       PRE   = nil
 

--- a/signet.gemspec
+++ b/signet.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.homepage = "https://github.com/google/signet/"
   gem.rdoc_options = ["--main", "README.md"]
   gem.summary = "Signet is an OAuth 1.0 / OAuth 2.0 implementation."
-  gem.required_ruby_version = ">= 1.9.3"
+  gem.required_ruby_version = ">= 2.4.0"
 
   gem.add_runtime_dependency "addressable", "~> 2.3"
   gem.add_runtime_dependency "faraday", "~> 0.9"
@@ -35,8 +35,6 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rspec", "~> 3.1"
   gem.add_development_dependency "simplecov", "~> 0.9"
   gem.add_development_dependency "yard", "~> 0.9", ">= 0.9.12"
-
-  gem.post_install_message = Signet::VERSION.warn_on_old_ruby_version
 
   if gem.respond_to? :metadata
     gem.metadata["changelog_uri"] = "https://github.com/google/signet/blob/master/CHANGELOG.md"


### PR DESCRIPTION
* Update gem requirements so Ruby 2.4.0 is the minimum.
* Remove the Ruby version warning.
* Update documentation.
* Update changelog and version for 0.12.0.
