### PR TITLE
Normalize the version constant

### DIFF
--- a/lib/signet/version.rb
+++ b/lib/signet/version.rb
@@ -12,16 +12,6 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-# Used to prevent the class/module from being loaded more than once
-unless defined? Signet::VERSION
-  module Signet
-    module VERSION
-      MAJOR = 0
-      MINOR = 11
-      TINY  = 0
-      PRE   = nil
-
-      STRING = [MAJOR, MINOR, TINY, PRE].compact.join "."
-    end
-  end
+module Signet
+  VERSION = "0.11.0".freeze
 end

--- a/signet.gemspec
+++ b/signet.gemspec
@@ -1,9 +1,9 @@
-# stub: signet 0.5.1 ruby lib
-require File.join(File.dirname(__FILE__), "lib/signet", "version")
+$LOAD_PATH.push File.expand_path("lib", __dir__)
+require "signet/version"
 
 Gem::Specification.new do |gem|
   gem.name = "signet"
-  gem.version = Signet::VERSION::STRING
+  gem.version = Signet::VERSION
 
   gem.required_rubygems_version = ">= 1.3.5"
   gem.require_paths = ["lib"]


### PR DESCRIPTION
This is probably "technically" a breaking change, although I'd be surprised if people are depending on the version constant being a module. This is needed to get this library under releasetool.