### PR TITLE
Update kokoro config for release job

### DIFF
--- a/.kokoro/release/signet.cfg
+++ b/.kokoro/release/signet.cfg
@@ -17,6 +17,37 @@ before_action {
   }
 }
 
+# Fetch magictoken to use with Magic Github Proxy 
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "releasetool-magictoken"
+      backend_type: FASTCONFIGPUSH
+    }
+  }
+}
+
+# Fetch api key to use with Magic Github Proxy 
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "magic-github-proxy-api-key"
+      backend_type: FASTCONFIGPUSH
+    }
+  }
+}
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "docuploader_service_account"
+    }
+  }
+}
+
 # Download resources for system tests (service account key, etc.)
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/google-cloud-ruby"
 
@@ -38,6 +69,11 @@ env_vars: {
 }
 
 env_vars: {
+    key: "TRAMPOLINE_SCRIPT"
+    value: "trampoline_v1.py"
+}
+
+env_vars: {
     key: "JOB_TYPE"
     value: "release"
 }
@@ -50,4 +86,9 @@ env_vars: {
 env_vars: {
     key: "REPO_DIR"
     value: "github/signet"
+}
+
+env_vars: {
+    key: "PACKAGE"
+    value: "signet"
 }


### PR DESCRIPTION
Update the config to match the corresponding configs in google-cloud-ruby.

Notes:
* I'm pretty sure `TRAMPOLINE_SCRIPT` is needed. The error message I'm currently getting from the kokoro job suggests what happens when it is missing.
* I'm slightly less sure about `PACKAGE` but all the individual package configs in google-cloud-ruby include it, so I assume it is needed to identify which package to publish.
* I'm not sure at all about the extra `keystore_resource`s. They are present in google-cloud-ruby's configs. Are they needed?