### PR TITLE
fix: Avoid rakefile task collisions, and fix tag format

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,7 +29,7 @@ task :release_gem, :tag do |_t, args|
     sh "bundle exec rake build"
   end
 
-  path_to_be_pushed = "pkg/#{version}.gem"
+  path_to_be_pushed = "pkg/signet-#{version}.gem"
   if File.file? path_to_be_pushed
     begin
       ::Gems.push File.new(path_to_be_pushed)

--- a/Rakefile
+++ b/Rakefile
@@ -3,12 +3,12 @@ require "json"
 require "rake"
 require "bundler/gem_tasks"
 
-task :release, :tag do |_t, args|
+task :release_gem, :tag do |_t, args|
   tag = args[:tag]
   raise "You must provide a tag to release." if tag.nil?
 
   # Verify the tag format "vVERSION"
-  m = tag.match(/v(?<version>\S*)/)
+  m = tag.match(/signet\/v(?<version>\S*)/)
   raise "Tag #{tag} does not match the expected format." if m.nil?
 
   version = m[:version]
@@ -77,7 +77,7 @@ namespace :kokoro do
                 .first.split("(").last.split(")").first || "0.1.0"
     end
     Rake::Task["kokoro:load_env_vars"].invoke
-    Rake::Task["release"].invoke "v/#{version}"
+    Rake::Task["release_gem"].invoke "signet/v#{version}"
   end
 end
 


### PR DESCRIPTION
Two additional fixes to the signet release task in the rakefile.

* Renamed the internal release task from `release` to `release_gem`. This is because `release` is already taken by the bundler rake plugin. When running the tasks, it appears the bundler task is taking precedence (possibly because it is defined first). In any case, we need our custom task to be executed instead because it handles rubygems credentials the way we want, so I renamed it to avoid the collision. (This issue does not affect the google-cloud-ruby rakefile because the toplevel rakefile never brings in the bundler plugin. Only the subdirectory rakefiles use the bundler tasks.)
* The `tag` parameter to the task was formatted one way when passed in but parsed another way, so some of the strings internally were formatted with extra slashes. I don't think this would actually have caused it to fail, but it certainly wouldn't help. Fixed. (This issue is not present in the google-cloud-ruby rakefile.)