### PR TITLE
add v to version url

### DIFF
--- a/rakelib/repo_metadata.rb
+++ b/rakelib/repo_metadata.rb
@@ -26,7 +26,7 @@ class RepoMetadata
     require_relative "../lib/signet/version.rb"
 
     @data.delete_if { |k, _| !allowed_fields.include?(k) }
-    @data["version"] = Signet::VERSION
+    @data["version"] = "v#{Signet::VERSION}"
   end
 
   def [] key


### PR DESCRIPTION
Keeping consistency with google-cloud-ruby gems. Changes:
googleapis.dev/ruby/signet/0.1.0 to
googleapis.dev/ruby/signet/v0.1.0