### PR TITLE
Release signet 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 0.13.0 / 2020-02-24
+
+* Support Faraday 1.x
+
 ### 0.12.0 / 2019-10-08
 
 * This version now requires Ruby 2.4.

--- a/lib/signet/version.rb
+++ b/lib/signet/version.rb
@@ -13,5 +13,5 @@
 #    limitations under the License.
 
 module Signet
-  VERSION = "0.12.0".freeze
+  VERSION = "0.13.0".freeze
 end


### PR DESCRIPTION
* Support Faraday 1.x

<details><summary>Commits since previous release</summary><pre><code>commit 23d733541eb9e741ff6279a4a975bea4e505eb06
Author: Joe Stein <joeaarons@gmail.com>
Date:   Mon Feb 24 15:29:38 2020 -0500

    feat: support Faraday 1.x

commit 3ce8da40d99c7631d8655fdc249cca9271e18d47
Author: Graham Paye <paye@google.com>
Date:   Tue Oct 29 16:08:24 2019 -0700

    add v to version url (#157)

commit 05e3f52dba07d54ea2229e5e8eb4c4485cc8cc4f
Author: Graham Paye <paye@google.com>
Date:   Thu Oct 17 20:26:47 2019 -0700

    chore: run linkinator on merges to master (#154)

commit 3e041a52ef4d7c3592cc1af79c02b6c997872739
Author: Graham Paye <paye@google.com>
Date:   Thu Oct 17 18:12:55 2019 -0700

    chore: use docker images from google-cloud-ruby (#156)

commit d2cbe633e86e2ac852168c61a3ca5149658a9148
Author: Graham Paye <paye@google.com>
Date:   Thu Oct 17 13:22:30 2019 -0700

    chore: remove travis build badge (#155)

commit e05623e3deb6c12bca73be0c9e51396516f90cff
Author: Graham Paye <paye@google.com>
Date:   Fri Oct 11 12:47:33 2019 -0700

    chore: upload docs to googleapis.dev on release (#153)

commit 8dc8ffd955ad58883f3610c4489acb8af7554461
Author: Daniel Azuma <dazuma@google.com>
Date:   Wed Oct 9 10:25:43 2019 -0700

    Update Gemfile with dependencies for release (#151)

commit 4b7a9da33b9329add3cde17123c8dc0da8ecc3bb
Author: Daniel Azuma <dazuma@google.com>
Date:   Tue Oct 8 17:34:30 2019 -0700

    fix: Avoid rakefile task collisions, and fix tag format

commit 732d8ccb53c83fc09ad2d72a4893df8ebbcf4926
Author: Daniel Azuma <dazuma@google.com>
Date:   Tue Oct 8 15:37:02 2019 -0700

    Fix missing require in rakefile (#149)

commit d509bb626346d8d1b505741b68ef8044834134e9
Author: Daniel Azuma <dazuma@google.com>
Date:   Tue Oct 8 15:08:52 2019 -0700

    Update kokoro config for release job (#148)
</code></pre></details>

<details><summary>Code changes since previous release</summary>

```diff
diff --git a/.kokoro/continuous/linux.cfg b/.kokoro/continuous/linux.cfg
index e479ec7..2036295 100644
--- a/.kokoro/continuous/linux.cfg
+++ b/.kokoro/continuous/linux.cfg
@@ -3,10 +3,10 @@
 build_file: "signet/.kokoro/trampoline.sh"
 
 # Configure the docker image for kokoro-trampoline.
-# Dockerfile is maintained at https://github.com/googleapis/google-cloud-ruby/tree/master/.kokoro/docker/ruby-multi
+# Dockerfile is maintained at https://github.com/googleapis/google-cloud-ruby/tree/master/.kokoro/docker/multi
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/ruby-multi"
+    value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi"
 }
 
 env_vars: {
diff --git a/.kokoro/continuous/post.cfg b/.kokoro/continuous/post.cfg
new file mode 100644
index 0000000..1171851
--- /dev/null
+++ b/.kokoro/continuous/post.cfg
@@ -0,0 +1,30 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+build_file: "signet/.kokoro/trampoline.sh"
+
+# Configure the docker image for kokoro-trampoline.
+# Dockerfile is maintained at https://github.com/googleapis/google-cloud-ruby/tree/master/.kokoro/docker/multi-node
+env_vars: {
+    key: "TRAMPOLINE_IMAGE"
+    value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi-node"
+}
+
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: "github/signet/.kokoro/build.sh"
+}
+
+env_vars: {
+    key: "TRAMPOLINE_SCRIPT"
+    value: "trampoline_v1.py"
+}
+
+env_vars: {
+    key: "OS"
+    value: "linux"
+}
+
+env_vars: {
+    key: "JOB_TYPE"
+    value: "post"
+}
diff --git a/.kokoro/presubmit/linux.cfg b/.kokoro/presubmit/linux.cfg
index 9a01a61..0b9dc92 100644
--- a/.kokoro/presubmit/linux.cfg
+++ b/.kokoro/presubmit/linux.cfg
@@ -5,7 +5,7 @@ build_file: "signet/.kokoro/trampoline.sh"
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/ruby-multi"
+    value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/multi"
 }
 
 env_vars: {
diff --git a/.kokoro/release/signet.cfg b/.kokoro/release.cfg
similarity index 56%
rename from .kokoro/release/signet.cfg
rename to .kokoro/release.cfg
index be03fa8..fd0f5c4 100644
--- a/.kokoro/release/signet.cfg
+++ b/.kokoro/release.cfg
@@ -17,6 +17,37 @@ before_action {
   }
 }
 
+# Fetch magictoken to use with Magic Github Proxy 
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "releasetool-magictoken"
+      backend_type: FASTCONFIGPUSH
+    }
+  }
+}
+
+# Fetch api key to use with Magic Github Proxy 
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "magic-github-proxy-api-key"
+      backend_type: FASTCONFIGPUSH
+    }
+  }
+}
+
+before_action {
+  fetch_keystore {
+    keystore_resource {
+      keystore_config_id: 73713
+      keyname: "docuploader_service_account"
+    }
+  }
+}
+
 # Download resources for system tests (service account key, etc.)
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/google-cloud-ruby"
 
@@ -29,7 +60,7 @@ build_file: "signet/.kokoro/trampoline.sh"
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/google-cloud-ruby/ruby-release"
+    value: "gcr.io/cloud-devrel-kokoro-resources/yoshi-ruby/release"
 }
 
 env_vars: {
@@ -37,6 +68,11 @@ env_vars: {
     value: "github/signet/.kokoro/build.sh"
 }
 
+env_vars: {
+    key: "TRAMPOLINE_SCRIPT"
+    value: "trampoline_v1.py"
+}
+
 env_vars: {
     key: "JOB_TYPE"
     value: "release"
@@ -51,3 +87,8 @@ env_vars: {
     key: "REPO_DIR"
     value: "github/signet"
 }
+
+env_vars: {
+    key: "PACKAGE"
+    value: "signet"
+}
diff --git a/.repo-metadata.json b/.repo-metadata.json
new file mode 100644
index 0000000..2936d14
--- /dev/null
+++ b/.repo-metadata.json
@@ -0,0 +1,5 @@
+{
+    "name": "signet",
+    "language": "ruby",
+    "distribution-name": "signet"
+}
\ No newline at end of file
diff --git a/Gemfile b/Gemfile
index e7bcefa..47d4af3 100644
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@ source "https://rubygems.org"
 gemspec
 
 gem "bundler", ">= 1.15"
+gem "gems", "~> 1.2"
 gem "hurley"
 gem "jruby-openssl", platforms: :jruby
diff --git a/README.md b/README.md
index eadcc50..f3e5fda 100644
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 </dl>
 
 [![Gem Version](https://badge.fury.io/rb/signet.svg)](https://badge.fury.io/rb/signet)
-[![Build Status](https://secure.travis-ci.org/google/signet.png)](http://travis-ci.org/google/signet)
 
 ## Description
 
diff --git a/Rakefile b/Rakefile
index a4607a7..0dae8e3 100644
--- a/Rakefile
+++ b/Rakefile
@@ -1,13 +1,14 @@
 require "rubygems"
+require "json"
 require "rake"
 require "bundler/gem_tasks"
 
-task :release, :tag do |_t, args|
+task :release_gem, :tag do |_t, args|
   tag = args[:tag]
   raise "You must provide a tag to release." if tag.nil?
 
   # Verify the tag format "vVERSION"
-  m = tag.match(/v(?<version>\S*)/)
+  m = tag.match /v(?<version>\S*)/
   raise "Tag #{tag} does not match the expected format." if m.nil?
 
   version = m[:version]
@@ -28,17 +29,24 @@ task :release, :tag do |_t, args|
     sh "bundle exec rake build"
   end
 
-  path_to_be_pushed = "pkg/#{version}.gem"
+  path_to_be_pushed = "pkg/signet-#{version}.gem"
+  gem_was_published = nil
   if File.file? path_to_be_pushed
     begin
-      ::Gems.push File.new(path_to_be_pushed)
+      response = ::Gems.push File.new(path_to_be_pushed)
+      puts response
+      raise unless response.include? "Successfully registered gem:"
+      gem_was_published = true
       puts "Successfully built and pushed signet for version #{version}"
     rescue StandardError => e
+      gem_was_published = false
       puts "Error while releasing signet version #{version}: #{e.message}"
     end
   else
     raise "Cannot build signet for version #{version}"
   end
+
+  Rake::Task["kokoro:publish_docs"].invoke if gem_was_published
 end
 
 task :ci do
@@ -76,7 +84,21 @@ namespace :kokoro do
                 .first.split("(").last.split(")").first || "0.1.0"
     end
     Rake::Task["kokoro:load_env_vars"].invoke
-    Rake::Task["release"].invoke "v/#{version}"
+    Rake::Task["release_gem"].invoke "v#{version}"
+  end
+
+  task :post do
+    require_relative "rakelib/link_checker.rb"
+
+    link_checker = LinkChecker.new
+    link_checker.run
+    exit link_checker.exit_status
+  end
+
+  task :publish_docs do
+    require_relative "rakelib/devsite_builder.rb"
+
+    DevsiteBuilder.new(__dir__).publish
   end
 end
 
diff --git a/rakelib/devsite_builder.rb b/rakelib/devsite_builder.rb
new file mode 100644
index 0000000..06ebb7a
--- /dev/null
+++ b/rakelib/devsite_builder.rb
@@ -0,0 +1,45 @@
+require "pathname"
+
+require_relative "repo_metadata.rb"
+
+class DevsiteBuilder
+  def initialize master_dir = "."
+    @master_dir = Pathname.new master_dir
+    @output_dir = "doc"
+    @metadata = RepoMetadata.from_source "#{master_dir}/.repo-metadata.json"
+  end
+
+  def build
+    FileUtils.remove_dir @output_dir if Dir.exist? @output_dir
+    markup = "--markup markdown"
+
+    Dir.chdir @master_dir do
+      cmds = ["-o #{@output_dir}", markup]
+      cmd "yard --verbose #{cmds.join ' '}"
+    end
+    @metadata.build @master_dir + @output_dir
+  end
+
+  def upload
+    Dir.chdir @output_dir do
+      opts = [
+        "--credentials=#{ENV['KOKORO_KEYSTORE_DIR']}/73713_docuploader_service_account",
+        "--staging-bucket=#{ENV.fetch 'STAGING_BUCKET', 'docs-staging'}",
+        "--metadata-file=./docs.metadata"
+      ]
+      cmd "python3 -m docuploader upload . #{opts.join ' '}"
+    end
+  end
+
+  def publish
+    build
+    upload
+  end
+
+  def cmd line
+    puts line
+    output = `#{line}`
+    puts output
+    output
+  end
+end
diff --git a/rakelib/link_checker.rb b/rakelib/link_checker.rb
new file mode 100644
index 0000000..d1b5f49
--- /dev/null
+++ b/rakelib/link_checker.rb
@@ -0,0 +1,64 @@
+require "open3"
+
+class LinkChecker
+  def initialize
+    @failed = false
+  end
+
+  def run
+    job_info
+    git_commit = ENV.fetch "KOKORO_GITHUB_COMMIT", "master"
+
+    markdown_files = Dir.glob "**/*.md"
+    broken_markdown_links = check_links markdown_files,
+                                        "https://github.com/googleapis/signet/tree/#{git_commit}",
+                                        " --skip '^(?!(\\Wruby.*google|.*google.*\\Wruby|.*cloud\\.google\\.com))'"
+
+    broken_devsite_links = check_links ["signet"],
+                                       "https://googleapis.dev/ruby",
+                                       "/latest/ --recurse --skip https:.*github.*"
+
+    puts_broken_links broken_markdown_links
+    puts_broken_links broken_devsite_links
+  end
+
+  def check_links location_list, base, tail
+    broken_links = Hash.new { |h, k| h[k] = [] }
+    location_list.each do |location|
+      out, err, st = Open3.capture3 "npx linkinator #{base}/#{location}#{tail}"
+      puts out
+      unless st.to_i.zero?
+        @failed = true
+        puts err
+      end
+      checked_links = out.split "\n"
+      checked_links.select! { |link| link =~ /\[\d+\]/ && !link.include?("[200]") }
+      unless checked_links.empty?
+        @failed = true
+        broken_links[location] += checked_links
+      end
+    end
+    broken_links
+  end
+
+  def puts_broken_links link_hash
+    link_hash.each do |location, links|
+      puts "#{location} contains the following broken links:"
+      links.each { |link| puts "  #{link}" }
+      puts
+    end
+  end
+
+  def job_info
+    line_length = "Using Ruby - #{RUBY_VERSION}".length + 8
+    puts
+    puts "#" * line_length
+    puts "### Using Ruby - #{RUBY_VERSION} ###"
+    puts "#" * line_length
+    puts
+  end
+
+  def exit_status
+    @failed ? 1 : 0
+  end
+end
diff --git a/rakelib/repo_metadata.rb b/rakelib/repo_metadata.rb
new file mode 100644
index 0000000..f371230
--- /dev/null
+++ b/rakelib/repo_metadata.rb
@@ -0,0 +1,59 @@
+require "json"
+
+class RepoMetadata
+  attr_reader :data
+
+  def initialize data
+    @data = data
+    normalize_data!
+  end
+
+  def allowed_fields
+    [
+      "name", "version", "language", "distribution-name",
+      "product-page", "github-repository", "issue-tracker"
+    ]
+  end
+
+  def build output_directory
+    fields = @data.to_a.map { |kv| "--#{kv[0]} #{kv[1]}" }
+    Dir.chdir output_directory do
+      cmd "python3 -m docuploader create-metadata #{fields.join ' '}"
+    end
+  end
+
+  def normalize_data!
+    require_relative "../lib/signet/version.rb"
+
+    @data.delete_if { |k, _| !allowed_fields.include?(k) }
+    @data["version"] = "v#{Signet::VERSION}"
+  end
+
+  def [] key
+    data[key]
+  end
+
+  def []= key, value
+    @data[key] = value
+  end
+
+  def cmd line
+    puts line
+    output = `#{line}`
+    puts output
+    output
+  end
+
+  def self.from_source source
+    if source.is_a? RepoMetadata
+      data = source.data
+    elsif source.is_a? Hash
+      data = source
+    elsif File.file? source
+      data = JSON.parse File.read(source)
+    else
+      raise "Source must be a path, hash, or RepoMetadata instance"
+    end
+    RepoMetadata.new data
+  end
+end
diff --git a/signet.gemspec b/signet.gemspec
index 55dd772..0eb21f2 100644
--- a/signet.gemspec
+++ b/signet.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.4.0"
 
   gem.add_runtime_dependency "addressable", "~> 2.3"
-  gem.add_runtime_dependency "faraday", "~> 0.9"
+  gem.add_runtime_dependency "faraday", ">= 0.17.3", "< 2.0"
   gem.add_runtime_dependency "jwt", ">= 1.5", "< 3.0"
   gem.add_runtime_dependency "multi_json", "~> 1.10"
 

```

</details>

This pull request was generated using releasetool.