### PR TITLE
Relax Faraday dependency version to allow 2.x

### DIFF
--- a/lib/signet/oauth_1/client.rb
+++ b/lib/signet/oauth_1/client.rb
@@ -926,7 +926,7 @@ module Signet
 
         content_type = request["Content-Type"].to_s
         content_type = content_type.split(";", 2).first if content_type.index ";"
-        if request.method == :post && content_type == "application/x-www-form-urlencoded"
+        if request.http_method == :post && content_type == "application/x-www-form-urlencoded"
           # Serializes the body in case a hash/array was passed. Noop if already string like
           encoder = Faraday::Request::UrlEncoded.new(->(_env) {})
           encoder.call env

--- a/lib/signet/oauth_1/server.rb
+++ b/lib/signet/oauth_1/server.rb
@@ -157,7 +157,7 @@ module Signet
           elsif options[:adapter]
             request = options[:adapter].adapt_request options[:request]
           end
-          method = request.method
+          method = request.http_method
           uri = request.path
           headers = request.headers
           body = request.body

--- a/lib/signet/oauth_1/server.rb
+++ b/lib/signet/oauth_1/server.rb
@@ -152,7 +152,7 @@ module Signet
       # @return [Hash] normalized request components
       def verify_request_components options = {}
         if options[:request]
-          if options[:request].is_a?(Faraday::Request) || options[:request].is_a?(Array)
+          if options[:request].is_a? Faraday::Request
             request = options[:request]
           elsif options[:adapter]
             request = options[:adapter].adapt_request options[:request]

--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -993,7 +993,14 @@ module Signet
         url = Addressable::URI.parse token_credential_uri
         parameters = generate_access_token_request options
         if client.is_a? Faraday::Connection
-          client.basic_auth client_id, client_secret if options[:use_basic_auth]
+          if options[:use_basic_auth]
+            # The Basic Auth middleware usage differs before and after Faraday v2
+            if Gem::Version.new(Faraday::VERSION).segments.first >= 2
+              client.request :authorization, :basic, client_id, client_secret
+            else
+              client.request :basic_auth, client_id, client_secret
+            end
+          end
           response = client.post url.normalize.to_s,
                                  Addressable::URI.form_encode(parameters),
                                  "Content-Type" => "application/x-www-form-urlencoded"

--- a/signet.gemspec
+++ b/signet.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.5"
 
   gem.add_runtime_dependency "addressable", "~> 2.8"
-  gem.add_runtime_dependency "faraday", ">= 0.17.3", "< 2.0"
+  gem.add_runtime_dependency "faraday", ">= 0.17.3", "< 3.0"
   gem.add_runtime_dependency "jwt", ">= 1.5", "< 3.0"
   gem.add_runtime_dependency "multi_json", "~> 1.10"
 

--- a/signet.gemspec
+++ b/signet.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = ">= 2.5"
 
   gem.add_runtime_dependency "addressable", "~> 2.8"
-  gem.add_runtime_dependency "faraday", ">= 0.17.3", "< 3.0"
+  gem.add_runtime_dependency "faraday", ">= 0.17.5", "< 3.0"
   gem.add_runtime_dependency "jwt", ">= 1.5", "< 3.0"
   gem.add_runtime_dependency "multi_json", "~> 1.10"
 

--- a/spec/signet/oauth_1/client_spec.rb
+++ b/spec/signet/oauth_1/client_spec.rb
@@ -602,7 +602,7 @@ describe Signet::OAuth1::Client, "configured" do
     # Repeat this because signatures change from test to test
     10.times do
       request = @client.generate_temporary_credential_request
-      expect(request.method).to eq :post
+      expect(request.http_method).to eq :post
       expect(request.path).to eq "http://example.com/temporary_credentials"
       authorization_header = request.headers["Authorization"]
       parameters = ::Signet::OAuth1.parse_authorization_header(
@@ -627,7 +627,7 @@ describe Signet::OAuth1::Client, "configured" do
       request = @client.generate_token_credential_request(
         verifier: "473f82d3"
       )
-      expect(request.method).to eq :post
+      expect(request.http_method).to eq :post
       expect(request.path).to eq "http://example.com/token_credentials"
       authorization_header = request.headers["Authorization"]
       parameters = ::Signet::OAuth1.parse_authorization_header(
@@ -659,7 +659,7 @@ describe Signet::OAuth1::Client, "configured" do
       signed_request = @client.generate_authenticated_request(
         request: original_request
       )
-      expect(signed_request.method).to eq :get
+      expect(signed_request.http_method).to eq :get
       expect(signed_request.path).to eq "https://photos.example.net/photos"
       expect(signed_request.params).to eq({ "file" => "vacation.jpg", "size" => "original" })
       authorization_header = signed_request.headers["Authorization"]
@@ -697,7 +697,7 @@ describe Signet::OAuth1::Client, "configured" do
       signed_request = @client.generate_authenticated_request(
         request: original_request
       )
-      expect(signed_request.method).to eq :post
+      expect(signed_request.http_method).to eq :post
       expect(signed_request.path).to eq "https://photos.example.net/photos"
       authorization_header = signed_request.headers["Authorization"]
       expect(signed_request.body).to eq "file=vacation.jpg&size=original"
@@ -739,7 +739,7 @@ describe Signet::OAuth1::Client, "configured" do
         # Should be same request object
         expect(original_request["Authorization"]).to eq signed_request["Authorization"]
 
-        expect(signed_request.method).to eq :get
+        expect(signed_request.http_method).to eq :get
         expect(signed_request.path).to eq "https://photos.example.net/photos"
         expect(signed_request.params).to eq ({ "file" => "vacation.jpg", "size" => "original" })
         authorization_header = signed_request.headers["Authorization"]
@@ -784,7 +784,7 @@ describe Signet::OAuth1::Client, "configured" do
         # Should be same request object
         expect(original_request["Authorization"]).to eq signed_request["Authorization"]
 
-        expect(signed_request.method).to eq :post
+        expect(signed_request.http_method).to eq :post
         expect(signed_request.path).to eq "https://photos.example.net/photos"
         authorization_header = signed_request.headers["Authorization"]
         # Can't rely on the order post parameters are encoded in.

--- a/spec/signet/oauth_1/server_spec.rb
+++ b/spec/signet/oauth_1/server_spec.rb
@@ -156,7 +156,7 @@ describe Signet::OAuth1::Server, "configured" do
   it "should raise an error if a bogus request is provided" do
     expect(lambda do
       @server.authenticate_resource_request(
-        request: []
+        request: Faraday::Request.new
       )
     end).to raise_error(ArgumentError)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,4 +7,3 @@ require "simplecov"
 require "faraday"
 
 SimpleCov.start if ENV["COVERAGE"]
-Faraday::Adapter.load_middleware :test


### PR DESCRIPTION
## Summary

Faraday 2.0 has been released earlier this year, and since this is one of the most popular gems (according to [bestgems](https://bestgems.org/gems/signet)) using Faraday as a dependency, it would be great if it would support the latest major version!

## Additional Notes

This PR removes a condition that would allow an array to be provided to the server as a request, because that simply doesn't work anymore. The "bug" was introduced [here](https://github.com/iMacTia/signet/commit/bb449aa64ca4fcbe2d7485370f871f444c388888#diff-cc62e9a1887143d3c39c443e1906d3edf397f78e6c098d9ce21a49a2b0bdaeddR150-R158) and the test around that (./spec/signet/oauth_1/server_spec.rb:157) has only been passing because calling `#method` on an Array causes an `ArgumentError`, rather than actually testing the request is complete. This test has also been udpated to pass an incomplete `Faraday::Request` which seems to be the intention behind that test