### PR TITLE
feat: Expose Granted Scopes while fetching credentials

### DIFF
--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -1049,9 +1049,9 @@ module Signet
         message = "  Server message:\n#{response.body.to_s.strip}" unless body.to_s.strip.empty?
 
         if status == 200
-          parsed_response = ::Signet::OAuth2.parse_credentials body, content_type 
+          parsed_response = ::Signet::OAuth2.parse_credentials body, content_type
           parsed_response["granted_scopes"] = parsed_response.delete("scope") if parsed_response
-          return parsed_response
+          parsed_response
         elsif [400, 401, 403].include? status
           message = "Authorization failed.#{message}"
           raise ::Signet::AuthorizationError.new message, response: response

--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -32,53 +32,53 @@ module Signet
       #
       # @param [Hash] options
       #   The configuration parameters for the client.
-      #   - <code>:authorization_uri</code> -
+      #   - `authorization_uri` -
       #     The authorization server's HTTP endpoint capable of
       #     authenticating the end-user and obtaining authorization.
-      #   - <code>:token_credential_uri</code> -
+      #   - `token_credential_uri` -
       #     The authorization server's HTTP endpoint capable of issuing
       #     tokens and refreshing expired tokens.
-      #   - <code>:client_id</code> -
+      #   - `client_id` -
       #     A unique identifier issued to the client to identify itself to the
       #     authorization server.
-      #   - <code>:client_secret</code> -
+      #   - `client_secret` -
       #     A shared symmetric secret issued by the authorization server,
       #     which is used to authenticate the client.
-      #   - <code>:scope</code> -
+      #   - `scope` -
       #     The scope of the access request, expressed either as an Array
       #     or as a space-delimited String.
-      #   - <code>:target_audience</code> -
+      #   - `target_audience` -
       #     The final target audience for ID tokens fetched by this client,
       #     as a String.
-      #   - <code>:state</code> -
+      #   - `state` -
       #     An arbitrary string designed to allow the client to maintain state.
-      #   - <code>:code</code> -
+      #   - `code` -
       #     The authorization code received from the authorization server.
-      #   - <code>:redirect_uri</code> -
+      #   - `redirect_uri` -
       #     The redirection URI used in the initial request.
-      #   - <code>:username</code> -
+      #   - `username` -
       #     The resource owner's username.
-      #   - <code>:password</code> -
+      #   - `password` -
       #     The resource owner's password.
-      #   - <code>:issuer</code> -
+      #   - `issuer` -
       #     Issuer ID when using assertion profile
-      #   - <code>:person</code> -
+      #   - `person` -
       #     Target user for assertions
-      #   - <code>:expiry</code> -
+      #   - `expiry` -
       #     Number of seconds assertions are valid for
-      #   - <code>:signing_key</code> -
+      #   - `signing_key` -
       #     Signing key when using assertion profile
-      #   - <code>:refresh_token</code> -
+      #   - `refresh_token` -
       #     The refresh token associated with the access token
       #     to be refreshed.
-      #   - <code>:access_token</code> -
+      #   - `access_token` -
       #     The current access token for this client.
-      #   - <code>:id_token</code> -
+      #   - `id_token` -
       #     The current ID token for this client.
-      #   - <code>:extension_parameters</code> -
+      #   - `extension_parameters` -
       #     When using an extension grant type, this the set of parameters used
       #     by that extension.
-      #   - <code>:granted_scopes</code> -
+      #   - `granted_scopes` -
       #     All scopes granted by authorization server.
       #
       # @example
@@ -120,57 +120,57 @@ module Signet
       #
       # @param [Hash] options
       #   The configuration parameters for the client.
-      #   - <code>:authorization_uri</code> -
+      #   - `authorization_uri` -
       #     The authorization server's HTTP endpoint capable of
       #     authenticating the end-user and obtaining authorization.
-      #   - <code>:token_credential_uri</code> -
+      #   - `token_credential_uri` -
       #     The authorization server's HTTP endpoint capable of issuing
       #     tokens and refreshing expired tokens.
-      #   - <code>:client_id</code> -
+      #   - `client_id` -
       #     A unique identifier issued to the client to identify itself to the
       #     authorization server.
-      #   - <code>:client_secret</code> -
+      #   - `client_secret` -
       #     A shared symmetric secret issued by the authorization server,
       #     which is used to authenticate the client.
-      #   - <code>:scope</code> -
+      #   - `scope` -
       #     The scope of the access request, expressed either as an Array
       #     or as a space-delimited String.
-      #   - <code>:target_audience</code> -
+      #   - `target_audience` -
       #     The final target audience for ID tokens fetched by this client,
       #     as a String.
-      #   - <code>:state</code> -
+      #   - `state` -
       #     An arbitrary string designed to allow the client to maintain state.
-      #   - <code>:code</code> -
+      #   - `code` -
       #     The authorization code received from the authorization server.
-      #   - <code>:redirect_uri</code> -
+      #   - `redirect_uri` -
       #     The redirection URI used in the initial request.
-      #   - <code>:username</code> -
+      #   - `username` -
       #     The resource owner's username.
-      #   - <code>:password</code> -
+      #   - `password` -
       #     The resource owner's password.
-      #   - <code>:issuer</code> -
+      #   - `issuer` -
       #     Issuer ID when using assertion profile
-      #   - <code>:audience</code> -
+      #   - `audience` -
       #     Target audience for assertions
-      #   - <code>:person</code> -
+      #   - `person` -
       #     Target user for assertions
-      #   - <code>:expiry</code> -
+      #   - `expiry` -
       #     Number of seconds assertions are valid for
-      #   - <code>:signing_key</code> -
+      #   - `signing_key` -
       #     Signing key when using assertion profile
-      #   - <code>:refresh_token</code> -
+      #   - `refresh_token` -
       #     The refresh token associated with the access token
       #     to be refreshed.
-      #   - <code>:access_token</code> -
+      #   - `access_token` -
       #     The current access token for this client.
-      #   - <code>:access_type</code> -
+      #   - `access_type` -
       #     The current access type parameter for #authorization_uri.
-      #   - <code>:id_token</code> -
+      #   - `id_token` -
       #     The current ID token for this client.
-      #   - <code>:extension_parameters</code> -
+      #   - `extension_parameters` -
       #     When using an extension grant type, this is the set of parameters used
       #     by that extension.
-      #   - <code>:granted_scopes</code> -
+      #   - `granted_scopes` -
       #     All scopes granted by authorization server.
       #
       # @example
@@ -839,10 +839,9 @@ module Signet
       ##
       # Sets the scopes returned by authorization server for this client.
       #
-      # @param [Array] new_granted_scopes
-      #   The scope of access the client is requesting.  This may be
-      #   expressed as either an Array of String objects or as a
-      #   space-delimited String.
+      # @param [String, nil] new_granted_scopes
+      #   The scope of access returned by authorization server. This will
+      #   ideally be expressed as space-delimited String.
       def granted_scopes= new_granted_scopes
         @granted_scopes = new_granted_scopes&.split
       end

--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -1048,20 +1048,20 @@ module Signet
 
         message = "  Server message:\n#{response.body.to_s.strip}" unless body.to_s.strip.empty?
 
-        if status == 200
-          parsed_response = ::Signet::OAuth2.parse_credentials body, content_type
-          parsed_response["granted_scopes"] = parsed_response.delete("scope") if parsed_response
-          parsed_response
-        elsif [400, 401, 403].include? status
+        if [400, 401, 403].include? status
           message = "Authorization failed.#{message}"
           raise ::Signet::AuthorizationError.new message, response: response
         elsif status.to_s[0] == "5"
           message = "Remote server error.#{message}"
           raise ::Signet::RemoteServerError, message
-        else
+        elsif status != 200
           message = "Unexpected status code: #{response.status}.#{message}"
           raise ::Signet::UnexpectedStatusError, message
         end
+        # status == 200
+        parsed_response = ::Signet::OAuth2.parse_credentials body, content_type
+        parsed_response["granted_scopes"] = parsed_response.delete("scope") if parsed_response
+        parsed_response
       end
 
       def fetch_access_token! options = {}

--- a/lib/signet/oauth_2/client.rb
+++ b/lib/signet/oauth_2/client.rb
@@ -32,53 +32,53 @@ module Signet
       #
       # @param [Hash] options
       #   The configuration parameters for the client.
-      #   - `authorization_uri` -
+      #   - `:authorization_uri` -
       #     The authorization server's HTTP endpoint capable of
       #     authenticating the end-user and obtaining authorization.
-      #   - `token_credential_uri` -
+      #   - `:token_credential_uri` -
       #     The authorization server's HTTP endpoint capable of issuing
       #     tokens and refreshing expired tokens.
-      #   - `client_id` -
+      #   - `:client_id` -
       #     A unique identifier issued to the client to identify itself to the
       #     authorization server.
-      #   - `client_secret` -
+      #   - `:client_secret` -
       #     A shared symmetric secret issued by the authorization server,
       #     which is used to authenticate the client.
-      #   - `scope` -
+      #   - `:scope` -
       #     The scope of the access request, expressed either as an Array
       #     or as a space-delimited String.
-      #   - `target_audience` -
+      #   - `:target_audience` -
       #     The final target audience for ID tokens fetched by this client,
       #     as a String.
-      #   - `state` -
+      #   - `:state` -
       #     An arbitrary string designed to allow the client to maintain state.
-      #   - `code` -
+      #   - `:code` -
       #     The authorization code received from the authorization server.
-      #   - `redirect_uri` -
+      #   - `:redirect_uri` -
       #     The redirection URI used in the initial request.
-      #   - `username` -
+      #   - `:username` -
       #     The resource owner's username.
-      #   - `password` -
+      #   - `:password` -
       #     The resource owner's password.
-      #   - `issuer` -
+      #   - `:issuer` -
       #     Issuer ID when using assertion profile
-      #   - `person` -
+      #   - `:person` -
       #     Target user for assertions
-      #   - `expiry` -
+      #   - `:expiry` -
       #     Number of seconds assertions are valid for
-      #   - `signing_key` -
+      #   - `:signing_key` -
       #     Signing key when using assertion profile
-      #   - `refresh_token` -
+      #   - `:refresh_token` -
       #     The refresh token associated with the access token
       #     to be refreshed.
-      #   - `access_token` -
+      #   - `:access_token` -
       #     The current access token for this client.
-      #   - `id_token` -
+      #   - `:id_token` -
       #     The current ID token for this client.
-      #   - `extension_parameters` -
+      #   - `:extension_parameters` -
       #     When using an extension grant type, this the set of parameters used
       #     by that extension.
-      #   - `granted_scopes` -
+      #   - `:granted_scopes` -
       #     All scopes granted by authorization server.
       #
       # @example
@@ -120,57 +120,57 @@ module Signet
       #
       # @param [Hash] options
       #   The configuration parameters for the client.
-      #   - `authorization_uri` -
+      #   - `:authorization_uri` -
       #     The authorization server's HTTP endpoint capable of
       #     authenticating the end-user and obtaining authorization.
-      #   - `token_credential_uri` -
+      #   - `:token_credential_uri` -
       #     The authorization server's HTTP endpoint capable of issuing
       #     tokens and refreshing expired tokens.
-      #   - `client_id` -
+      #   - `:client_id` -
       #     A unique identifier issued to the client to identify itself to the
       #     authorization server.
-      #   - `client_secret` -
+      #   - `:client_secret` -
       #     A shared symmetric secret issued by the authorization server,
       #     which is used to authenticate the client.
-      #   - `scope` -
+      #   - `:scope` -
       #     The scope of the access request, expressed either as an Array
       #     or as a space-delimited String.
-      #   - `target_audience` -
+      #   - `:target_audience` -
       #     The final target audience for ID tokens fetched by this client,
       #     as a String.
-      #   - `state` -
+      #   - `:state` -
       #     An arbitrary string designed to allow the client to maintain state.
-      #   - `code` -
+      #   - `:code` -
       #     The authorization code received from the authorization server.
-      #   - `redirect_uri` -
+      #   - `:redirect_uri` -
       #     The redirection URI used in the initial request.
-      #   - `username` -
+      #   - `:username` -
       #     The resource owner's username.
-      #   - `password` -
+      #   - `:password` -
       #     The resource owner's password.
-      #   - `issuer` -
+      #   - `:issuer` -
       #     Issuer ID when using assertion profile
-      #   - `audience` -
+      #   - `:audience` -
       #     Target audience for assertions
-      #   - `person` -
+      #   - `:person` -
       #     Target user for assertions
-      #   - `expiry` -
+      #   - `:expiry` -
       #     Number of seconds assertions are valid for
-      #   - `signing_key` -
+      #   - `:signing_key` -
       #     Signing key when using assertion profile
-      #   - `refresh_token` -
+      #   - `:refresh_token` -
       #     The refresh token associated with the access token
       #     to be refreshed.
-      #   - `access_token` -
+      #   - `:access_token` -
       #     The current access token for this client.
-      #   - `access_type` -
+      #   - `:access_type` -
       #     The current access type parameter for #authorization_uri.
-      #   - `id_token` -
+      #   - `:id_token` -
       #     The current ID token for this client.
-      #   - `extension_parameters` -
+      #   - `:extension_parameters` -
       #     When using an extension grant type, this is the set of parameters used
       #     by that extension.
-      #   - `granted_scopes` -
+      #   - `:granted_scopes` -
       #     All scopes granted by authorization server.
       #
       # @example
@@ -831,7 +831,7 @@ module Signet
       ##
       # Returns the scopes granted by the authorization server.
       #
-      # @return [Array] The scope of access returned by the authorization server.
+      # @return [Array, nil] The scope of access returned by the authorization server.
       def granted_scopes
         @granted_scopes
       end
@@ -839,11 +839,20 @@ module Signet
       ##
       # Sets the scopes returned by authorization server for this client.
       #
-      # @param [String, nil] new_granted_scopes
+      # @param [String, Array, nil] new_granted_scopes
       #   The scope of access returned by authorization server. This will
       #   ideally be expressed as space-delimited String.
       def granted_scopes= new_granted_scopes
-        @granted_scopes = new_granted_scopes&.split
+        case new_granted_scopes
+        when Array
+          @granted_scopes = new_granted_scopes
+        when String
+          @granted_scopes = new_granted_scopes.split
+        when nil
+          @granted_scopes = nil
+        else
+          raise TypeError, "Expected Array or String, got #{new_granted_scopes.class}"
+        end
       end
 
       ##

--- a/spec/signet/oauth_2/client_spec.rb
+++ b/spec/signet/oauth_2/client_spec.rb
@@ -64,7 +64,7 @@ describe Signet::OAuth2::Client, "unconfigured" do
   end
 
   it "should allow to set granted scopes" do
-    @client.granted_scopes = ["granted_scopes1 granted_scopes2"]
+    @client.granted_scopes = "granted_scopes1 granted_scopes2"
     expect(@client.granted_scopes).to eq ["granted_scopes1", "granted_scopes2"]
   end
 
@@ -381,14 +381,14 @@ describe Signet::OAuth2::Client, "configured for Google userinfo API" do
       refresh_token: "54321",
       :expires_in    => 3600,
       :issued_at     => issued_at,
-      :granted_scopes => ["scope1"]
+      :granted_scopes => "scope1"
     )
     expect(@client.access_token).to eq "12345"
     expect(@client.refresh_token).to eq "54321"
     expect(@client.expires_in).to eq 3600
     expect(@client.issued_at).to eq issued_at
     expect(@client).to_not be_expired
-    expect(@client).to eq ["scope1"]
+    expect(@client.granted_scopes).to eq ["scope1"]
   end
 
   it "should handle expires as equivalent to expires_in" do

--- a/spec/signet/oauth_2/client_spec.rb
+++ b/spec/signet/oauth_2/client_spec.rb
@@ -63,8 +63,13 @@ describe Signet::OAuth2::Client, "unconfigured" do
     expect(@client.scope).to eq ["legit", "alsolegit"]
   end
 
-  it "should allow to set granted scopes" do
+  it "should allow to set granted scopes as String" do
     @client.granted_scopes = "granted_scopes1 granted_scopes2"
+    expect(@client.granted_scopes).to eq ["granted_scopes1", "granted_scopes2"]
+  end
+
+  it "should allow to set granted scopes as Array" do
+    @client.granted_scopes = ["granted_scopes1", "granted_scopes2"]
     expect(@client.granted_scopes).to eq ["granted_scopes1", "granted_scopes2"]
   end
 

--- a/spec/signet/oauth_2/client_spec.rb
+++ b/spec/signet/oauth_2/client_spec.rb
@@ -63,6 +63,11 @@ describe Signet::OAuth2::Client, "unconfigured" do
     expect(@client.scope).to eq ["legit", "alsolegit"]
   end
 
+  it "should allow to set granted scopes" do
+    @client.granted_scopes = ["granted_scopes1 granted_scopes2"]
+    expect(@client.granted_scopes).to eq ["granted_scopes1", "granted_scopes2"]
+  end
+
   it "should raise an error if a bogus redirect URI is provided" do
     expect(lambda do
       @client = Signet::OAuth2::Client.new redirect_uri: :bogus
@@ -375,13 +380,15 @@ describe Signet::OAuth2::Client, "configured for Google userinfo API" do
       :access_token  => "12345",
       refresh_token: "54321",
       :expires_in    => 3600,
-      :issued_at     => issued_at
+      :issued_at     => issued_at,
+      :granted_scopes => ["scope1"]
     )
     expect(@client.access_token).to eq "12345"
     expect(@client.refresh_token).to eq "54321"
     expect(@client.expires_in).to eq 3600
     expect(@client.issued_at).to eq issued_at
     expect(@client).to_not be_expired
+    expect(@client).to eq ["scope1"]
   end
 
   it "should handle expires as equivalent to expires_in" do


### PR DESCRIPTION
When user credentials are fetched and refreshed, the OAuth server returns granted scopes. This change exposes those scopes in the credentials object