### PR TITLE
chore: remove warnings of unused variables in the test code

### DIFF
--- a/spec/signet/oauth_1/client_spec.rb
+++ b/spec/signet/oauth_1/client_spec.rb
@@ -548,7 +548,7 @@ describe Signet::OAuth1::Client, "configured" do
 
   it "should not raise an error if a request is "\
      "provided without a connection" do
-    request = @client.generate_authenticated_request(
+    @client.generate_authenticated_request(
       request: conn.build_request(:get) do |req|
         req.url "http://www.example.com/"
       end

--- a/spec/signet/oauth_2/client_spec.rb
+++ b/spec/signet/oauth_2/client_spec.rb
@@ -207,7 +207,7 @@ describe Signet::OAuth2::Client, "configured for assertions profile" do
       jwt = @client.to_jwt
       expect(jwt).not_to be_nil
 
-      claim, header = JWT.decode jwt, @key.public_key, true, algorithm: "RS256"
+      claim, _header = JWT.decode jwt, @key.public_key, true, algorithm: "RS256"
       expect(claim["iss"]).to eq "app@example.com"
       expect(claim["scope"]).to eq "https://www.googleapis.com/auth/userinfo.profile"
       expect(claim["aud"]).to eq "https://oauth2.googleapis.com/token"
@@ -218,7 +218,7 @@ describe Signet::OAuth2::Client, "configured for assertions profile" do
       jwt = @client.to_jwt
       expect(jwt).not_to be_nil
 
-      claim, header = JWT.decode jwt, @key.public_key, true, algorithm: "RS256"
+      claim, _header = JWT.decode jwt, @key.public_key, true, algorithm: "RS256"
       expect(claim["iss"]).to eq "app@example.com"
       expect(claim["prn"]).to eq "user@example.com"
       expect(claim["scope"]).to eq "https://www.googleapis.com/auth/userinfo.profile"
@@ -230,7 +230,7 @@ describe Signet::OAuth2::Client, "configured for assertions profile" do
       jwt = @client.to_jwt
       expect(jwt).not_to be_nil
 
-      claim, header = JWT.decode jwt, @key.public_key, true, algorithm: "RS256"
+      claim, _header = JWT.decode jwt, @key.public_key, true, algorithm: "RS256"
       expect(claim["iss"]).to eq "app@example.com"
       expect(claim["prn"]).to eq "user@example.com"
       expect(claim["scope"]).to eq "https://www.googleapis.com/auth/userinfo.profile"
@@ -242,7 +242,7 @@ describe Signet::OAuth2::Client, "configured for assertions profile" do
       jwt = @client.to_jwt
       expect(jwt).not_to be_nil
 
-      claim, header = JWT.decode jwt, @key.public_key, true, algorithm: "RS256"
+      claim, _header = JWT.decode jwt, @key.public_key, true, algorithm: "RS256"
       expect(claim["iss"]).to eq "app@example.com"
       expect(claim["sub"]).to eq "user@example.com"
       expect(claim["scope"]).to eq "https://www.googleapis.com/auth/userinfo.profile"
@@ -266,7 +266,7 @@ describe Signet::OAuth2::Client, "configured for assertions profile" do
       stubs = Faraday::Adapter::Test::Stubs.new do |stub|
         stub.post "/token" do |env|
           params = Addressable::URI.form_unencode env[:body]
-          claim, header = JWT.decode params.assoc("assertion").last, @key.public_key, true, algorithm: "RS256"
+          JWT.decode params.assoc("assertion").last, @key.public_key, true, algorithm: "RS256"
           expect(params.assoc("grant_type")).to eq ["grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"]
           build_json_response(
             "access_token" => "1/abcdef1234567890",
@@ -301,7 +301,7 @@ describe Signet::OAuth2::Client, "configured for assertions profile" do
       jwt = @client.to_jwt
       expect(jwt).not_to be_nil
 
-      claim, header = JWT.decode jwt, @key, true, algorithm: "HS256"
+      claim, _header = JWT.decode jwt, @key, true, algorithm: "HS256"
       expect(claim["iss"]).to eq "app@example.com"
       expect(claim["scope"]).to eq "https://www.googleapis.com/auth/userinfo.profile"
       expect(claim["aud"]).to eq "https://oauth2.googleapis.com/token"
@@ -814,7 +814,7 @@ describe Signet::OAuth2::Client, "configured for Google userinfo API" do
     @client.client_id = "client-12345"
     @client.client_secret = "secret-12345"
     @client.access_token = "12345"
-    request = @client.generate_authenticated_request(
+    @client.generate_authenticated_request(
       realm:   "Example",
       request: conn.build_request(:get) do |req|
         req.url "https://www.googleapis.com/oauth2/v1/userinfo?alt=json"
@@ -1286,7 +1286,7 @@ describe Signet::OAuth2::Client, "configured for id tokens" do
     stubs = Faraday::Adapter::Test::Stubs.new do |stub|
       stub.post "/token" do |env|
         params = Addressable::URI.form_unencode env[:body]
-        claim, header = JWT.decode params.assoc("assertion").last, @key.public_key, true, algorithm: "RS256"
+        claim, _header = JWT.decode params.assoc("assertion").last, @key.public_key, true, algorithm: "RS256"
         expect(params.assoc("grant_type")).to eq ["grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"]
         expect(claim["target_audience"]).to eq "https://api.example.com"
         expect(claim["iss"]).to eq "app@example.com"

--- a/spec/signet/oauth_2_spec.rb
+++ b/spec/signet/oauth_2_spec.rb
@@ -70,7 +70,7 @@ describe Signet::OAuth2 do
 
     it "should not allow unquoted strings that do not match tchar" do
       expect(lambda do
-        parameters = Signet::OAuth2.parse_authorization_header(
+        Signet::OAuth2.parse_authorization_header(
           "OAuth vF9dft4qmT, first=one:1"
         )
       end).to raise_error(Signet::ParseError)


### PR DESCRIPTION
When I ran tests for the repository, I got the warning messages below.

```
spec/signet/oauth_1/client_spec.rb:551: warning: assigned but unused variable - request
spec/signet/oauth_2/client_spec.rb:210: warning: assigned but unused variable - header
spec/signet/oauth_2/client_spec.rb:221: warning: assigned but unused variable - header
spec/signet/oauth_2/client_spec.rb:233: warning: assigned but unused variable - header
spec/signet/oauth_2/client_spec.rb:245: warning: assigned but unused variable - header
spec/signet/oauth_2/client_spec.rb:269: warning: assigned but unused variable - claim
spec/signet/oauth_2/client_spec.rb:269: warning: assigned but unused variable - header
spec/signet/oauth_2/client_spec.rb:304: warning: assigned but unused variable - header
spec/signet/oauth_2/client_spec.rb:817: warning: assigned but unused variable - request
spec/signet/oauth_2/client_spec.rb:1289: warning: assigned but unused variable - header
spec/signet/oauth_2_spec.rb:73: warning: assigned but unused variable - parameters
```