### PR TITLE
fix: require "English" for `$OUTPUT_RECORD_SEPARATOR`

### DIFF
--- a/lib/signet.rb
+++ b/lib/signet.rb
@@ -12,6 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+require "English"
 require "signet/version"
 
 module Signet # :nodoc:


### PR DESCRIPTION
`$OUTPUT_RECORD_SEPARATOR` is defined as the alias of `$\` in `English` gem. Without this gem, the variable is not defined, and Ruby warns with the message below.

```
warning: global variable '$OUTPUT_RECORD_SEPARATOR' not initialized
```

By the way, I'm not confident the code really requires the global variable, but I kept the behavior as it is.

```ruby
token = /[-!#{$OUTPUT_RECORD_SEPARATOR}%&'*+.^_`|~0-9a-zA-Z]+/
```